### PR TITLE
meta viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no"/>
     <meta property="og:title" content="J. Tucker Wray-Portfolio Worx"/>
     <meta property="og:description" content="J Tucker Wray- Full-Stack Developer|| Javascript React Redux Express Node Heroku AWS Firebase Serverless Python GoLang PostgreSQL
     I'm Tucker Wray I write full stack Javascript. Giving back is important to me. I enjoy busting my knuckles under my jeep as much as I do squashing bugs in my terminal. I enjoy stuff thats not easy like that. Anything that puzzles me and encourages ingenuity is going to keep my attention."/>
@@ -57,7 +57,7 @@
           Assistant/ProjectLead. After work each day I login to LambdaSchool
           as a part-time student in the final unit of the 18 month Full-Stack
           Web track. I spend a fair amount of time working on code reviews,
-          leading a stand ups, and really get a kick out of squashing bugs
+          leading stand ups, and really get a kick out of squashing bugs
           pair programming style.
         </p>
         <p>


### PR DESCRIPTION
## janky mobileview - metatag?
## fix introduction typo 

- displays @ 0.5width
- inspector content width reads @ 320px
- matches the preview choice
- extra whitespace is in the 500px+ area
- adds ", user-scalable=no" to current viewport meta tag



[![ screenshot of  janky mobile view](https://i.imgur.com/5WXTcO7.png)]